### PR TITLE
Remove default MCP transport error handler

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -180,7 +180,6 @@ class YepCodeMcpServer extends Server {
     this.runCodeCleanup = runCodeCleanup;
     this.skipCodingRules = skipCodingRules;
     this.setupHandlers();
-    this.setupErrorHandling();
 
     try {
       this.yepCodeRun = new YepCodeRun(config);
@@ -204,12 +203,6 @@ class YepCodeMcpServer extends Server {
         "Exception while initializing YepCode. Have you set the YEPCODE_API_TOKEN environment variable?"
       );
     }
-  }
-
-  private setupErrorHandling(): void {
-    this.onerror = (error) => {
-      this.logger.error("[MCP Error]", error);
-    };
   }
 
   private setupHandlers(): void {


### PR DESCRIPTION
Let consuming projects decide how to handle transport errors by not setting server.onerror by default. They can assign server.onerror after instantiation if they need custom handling (logging, etc)