### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ YepCode is built to be the ideal platform for running a **dynamic MCP tools serv
 
 For complete documentation, see the [YepCode MCP Server docs](https://yepcode.io/docs/mcp-server/).
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yepcode-mcp-server-js).
+
 ## Installation
 
 This package lets you run the YepCode MCP server **locally** or in your own infrastructure (NPX, Docker, or custom deployment). Integrate it with AI platforms like [Cursor](https://cursor.sh) or [Claude Desktop](https://www.anthropic.com/news/claude-desktop).


### PR DESCRIPTION
Love the project!
Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/yepcode-mcp-server-js).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code, APIs, or security-sensitive logic is modified.
> 
> **Overview**
> **Documentation update:** the README now includes a new **Hosted deployment** section linking to a Fronteir AI page as an additional hosted option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e21b00a902124622d95e6075d89d1bf419bbac1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->